### PR TITLE
Allowed for More Modular Account Styling & Improved High Security Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 /libpeerconnection.log
 npm-debug.log*
 testem.log
+
+# Ignore Sublime files
+*.sublime*

--- a/addon/components/delete-user.js
+++ b/addon/components/delete-user.js
@@ -76,7 +76,6 @@ export default Ember.Component.extend({
             });
 
           }, (error) => {
-            Ember.Logger.log("ERROR 1");
             Ember.Logger.log(error);
             scope.get('notify').alert(scope.get('account-config').messages['incorrectPassword']);
             reject();

--- a/addon/components/delete-user.js
+++ b/addon/components/delete-user.js
@@ -1,5 +1,7 @@
 import Ember from 'ember';
+import Changeset from 'ember-changeset';
 import layout from '../templates/components/delete-user';
+import firebase from 'firebase';
 
 export default Ember.Component.extend({
   layout,
@@ -9,50 +11,84 @@ export default Ember.Component.extend({
   store: Ember.inject.service(),
   notify: Ember.inject.service(),
   'account-config': Ember.inject.service(),
-  reauthenticate: Ember.inject.service(),
   hasError: false,
+
   actions: {
-    deleteUser(form){
+    deleteUser(form) {
       const scope = this,
-            config = scope.get('account-config'),
-            user = this.get('firebaseApp').auth().currentUser;
+        config = scope.get('account-config'),
+        user = this.get('firebaseApp').auth().currentUser;
+
       return new Ember.RSVP.Promise(function(resolve, reject) {
-        if(user && user.email === form.email){
-          if(config.hardDelete){
-            scope.get('store').findRecord("user", user.uid).then((rec) => {
-              rec.destroyRecord();
-              scope.get('notify').success(config.messages['successfulDeleteAccount']);
-            });
-          }
-          user.delete().then(() => {
-            scope.get('session').close().then(() => {
-              scope.get('router').transitionTo('index');
-              resolve();
-            }, reject);
-          }, (error) => {
-            if(error.code === 'auth/requires-recent-login') {
+        if(scope.get('session.isAuthenticated')) {
+          const currentUser = scope.get('firebaseApp').auth().currentUser;
+
+          // Get credentials for reauthentication via the user email and the entered password
+          let credential = firebase.auth.EmailAuthProvider.credential(currentUser.email, form.get('currentPassword'));
+
+          currentUser.reauthenticate(credential).then(() => {
+
+            scope.get('store').findRecord('user', currentUser.uid).then((record) => {
+              if(config.hardDelete) {
+                // if hard deleting, destroy the user
+                rec.destroyRecord();
+
+                user.delete().then(() => {
+                  scope.get('session').close().then(() => {
+                    scope.get('router').transitionTo('index');
+                    scope.get('notify').success(config.messages['successfulDeleteAccount']);
+                    resolve();
+                  }, reject);
+                }, (error) => {
+                  Ember.Logger.log(error);
+                  scope.get('notify').alert(config.messages['unsuccessfulDeleteAccount']);
+                  reject();
+                });
+              }
+              else {
+                // if not hard deleting the user, flag the account as deleted
+                if(config.deleted)
+                  record.set(config.deleted, true);
+
+                record.save().then(() => {
+                  user.delete().then(() => {
+                    scope.get('session').close().then(() => {
+                      scope.get('router').transitionTo('index');
+                      scope.get('notify').success(config.messages['successfulDeleteAccount']);
+                      resolve();
+                    }, reject);
+                  }, (error) => {
+                    Ember.Logger.log(error);
+                    scope.get('notify').alert(config.messages['unsuccessfulDeleteAccount']);
+                    reject();
+                  });
+
+                  resolve();
+                }, (error) => {
+                  scope.get('notify').alert(config.messages['successfulDeleteAccount']);
+                  reject();
+                });
+              }
+            }, (error) => {
+              Ember.Logger.log(error);
               scope.get('notify').alert(config.messages['unsuccessfulDeleteAccount']);
-              scope.get('reauthenticate').set('shouldReauthenticate', true);
-            }
+              reject();
+            });
+
+          }, (error) => {
+            Ember.Logger.log("ERROR 1");
+            Ember.Logger.log(error);
+            scope.get('notify').alert(scope.get('account-config').messages['incorrectPassword']);
             reject();
           });
         }
-        else {
-          if(!scope.get("hasError")){
-            scope.get('notify').alert(config.messages['unsuccessfulDeleteAccount']);
-            Ember.$('.ef-account-form-input').append('<div class="form-field--errors">Incorrect email. Please re-enter your e-mail.</div>');
-            scope.set("hasError", true);
-          }
-          reject();
-        }
+
+        reject();
       });
     }
   },
-  shouldReauthenticate: Ember.computed('reauthenticate.shouldReauthenticate', function() {
-    return this.get('reauthenticate.shouldReauthenticate');
-  }),
   init() {
     this._super(...arguments);
-    this.delete_form = {email: ''};
+    this.delete_form = new Changeset({currentPassword: ''});
   }
 });

--- a/addon/components/update-email.js
+++ b/addon/components/update-email.js
@@ -59,5 +59,7 @@ export default Ember.Component.extend({
   init() {
     this._super(...arguments);
     this.email = new Changeset({email: '', emailConfirmation: ''}, lookupValidator(EmailValidations), EmailValidations);
+    this.currentEmail = this.get('firebaseApp').auth().currentUser.email;
+    this.currentEmailPrompt = this.get('account-config').messages['currentEmailPrompt'];
   }
 });

--- a/addon/components/update-email.js
+++ b/addon/components/update-email.js
@@ -3,6 +3,7 @@ import layout from '../templates/components/update-email';
 import EmailValidations from '../validations/email';
 import Changeset from 'ember-changeset';
 import lookupValidator from 'ember-changeset-validations';
+import firebase from 'firebase';
 
 export default Ember.Component.extend({
   layout,
@@ -11,7 +12,6 @@ export default Ember.Component.extend({
   session: Ember.inject.service(),
   notify: Ember.inject.service(),
   'account-config': Ember.inject.service(),
-  reauthenticate: Ember.inject.service(),
   store: Ember.inject.service(),
   actions: {
     updateEmail(form) {
@@ -19,46 +19,55 @@ export default Ember.Component.extend({
       return new Ember.RSVP.Promise(function(resolve, reject) {
         if (scope.get('session.isAuthenticated') && scope.get('email').get('isValid')) {
           const currentUser = scope.get('firebaseApp').auth().currentUser;
-          currentUser.updateEmail(form.get('email')).then(() => {
-            if (scope.get('account-config').email) {
-              scope.get('store').findRecord('user', currentUser.uid).then((data) => {
-                data.set(scope.get('account-config').email, form.get('email'));
-                data.save().then(() => {
-                  scope.get('notify').success(scope.get('account-config').messages['successfulUpdateEmail']);
-                  resolve();
+
+          // Get credentials for reauthentication via the user email and the entered password
+          const credential = firebase.auth.EmailAuthProvider.credential(currentUser.email, form.get('currentPassword'));
+
+          currentUser.reauthenticate(credential).then(() => {
+
+            currentUser.updateEmail(form.get('email')).then(() => {
+              if (scope.get('account-config').email) {
+                scope.get('store').findRecord('user', currentUser.uid).then((data) => {
+                  data.set(scope.get('account-config').email, form.get('email'));
+
+                  data.save().then(() => {
+                    scope.get('notify').success(scope.get('account-config').messages['successfulUpdateEmail']);
+                    resolve();
+                  }, (error) => {
+                    scope.get('notify').alert(scope.get('account-config').messages['unsuccessfulUpdateEmail']);
+                    reject();
+                  });
+
                 }, (error) => {
                   scope.get('notify').alert(scope.get('account-config').messages['unsuccessfulUpdateEmail']);
                   reject();
                 });
-              }, (error) => {
-                scope.get('notify').alert(scope.get('account-config').messages['unsuccessfulUpdateEmail']);
-                reject();
-              });
-            }
-            else {
-              scope.get('notify').success(scope.get('account-config').messages['successfulUpdateEmail']);
-              resolve();
-            }
+              }
+              else {
+                scope.get('notify').success(scope.get('account-config').messages['successfulUpdateEmail']);
+                resolve();
+              }
+            }, (error) => {
+              Ember.Logger.log(error);
+              scope.get('notify').alert(scope.get('account-config').messages['unsuccessfulUpdateEmail']);
+              reject();
+            });
+
           }, (error) => {
             Ember.Logger.log(error);
-            if(error.code === 'auth/requires-recent-login') {
-              scope.get('notify').alert(scope.get('account-config').messages['unsuccessfulUpdateEmail']);
-              scope.get('reauthenticate').set('shouldReauthenticate', true);
-            }
+            scope.get('notify').alert(scope.get('account-config').messages['incorrectPassword']);
             reject();
           });
         }
+
         reject();
       });
     }
   },
-  shouldReauthenticate: Ember.computed('reauthenticate.shouldReauthenticate', function() {
-    return this.get('reauthenticate.shouldReauthenticate');
-  }),
   EmailValidations,
   init() {
     this._super(...arguments);
-    this.email = new Changeset({email: '', emailConfirmation: ''}, lookupValidator(EmailValidations), EmailValidations);
+    this.email = new Changeset({email: '', emailConfirmation: '', currentPassword: ''}, lookupValidator(EmailValidations), EmailValidations);
     this.currentEmail = this.get('firebaseApp').auth().currentUser.email;
     this.currentEmailPrompt = this.get('account-config').messages['currentEmailPrompt'];
   }

--- a/addon/components/update-password.js
+++ b/addon/components/update-password.js
@@ -3,6 +3,7 @@ import layout from '../templates/components/update-password';
 import PasswordValidations from '../validations/password';
 import Changeset from 'ember-changeset';
 import lookupValidator from 'ember-changeset-validations';
+import firebase from 'firebase';
 
 export default Ember.Component.extend({
   layout,
@@ -11,32 +12,39 @@ export default Ember.Component.extend({
   session: Ember.inject.service(),
   notify: Ember.inject.service(),
   'account-config': Ember.inject.service(),
-  reauthenticate: Ember.inject.service(),
   actions: {
     updatePassword(form) {
       const scope = this;
       return new Ember.RSVP.Promise(function(resolve, reject) {
         if (scope.get('session.isAuthenticated') && scope.get('password').get('isValid')) {
-          scope.get('firebaseApp').auth().currentUser.updatePassword(form.get('password')).then(() => {
-            scope.get('notify').success(scope.get('account-config').messages['successfulUpdatePassword']);
-            resolve();
-          }, (error) => {
-            if(error.code === 'auth/requires-recent-login') {
+          const currentUser = scope.get('firebaseApp').auth().currentUser;
+
+          // Get credentials for reauthentication via the user email and the entered password
+          const credential = firebase.auth.EmailAuthProvider.credential(currentUser.email, form.get('currentPassword'));
+
+          currentUser.reauthenticate(credential).then(() => {
+
+            scope.get('firebaseApp').auth().currentUser.updatePassword(form.get('password')).then(() => {
+              scope.get('notify').success(scope.get('account-config').messages['successfulUpdatePassword']);
+              resolve();
+            }, (error) => {
+              Ember.Logger.log(error);
               scope.get('notify').alert(scope.get('account-config').messages['unsuccessfulUpdatePassword']);
-              scope.get('reauthenticate').set('shouldReauthenticate', true);
-            }
+              reject();
+            });
+          }, (error) => {
+            Ember.Logger.log(error);
+            scope.get('notify').alert(scope.get('account-config').messages['incorrectPassword']);
             reject();
           });
         }
+
         reject();
       });
     }
   },
-  shouldReauthenticate: Ember.computed('reauthenticate.shouldReauthenticate', function() {
-    return this.get('reauthenticate.shouldReauthenticate');
-  }),
   init() {
     this._super();
-    this.password = new Changeset({password: '', passwordConfirmation: ''}, lookupValidator(PasswordValidations), PasswordValidations);
+    this.password = new Changeset({password: '', passwordConfirmation: '', currentPassword: ''}, lookupValidator(PasswordValidations), PasswordValidations);
   }
 });

--- a/addon/templates/components/account-menu.hbs
+++ b/addon/templates/components/account-menu.hbs
@@ -2,7 +2,7 @@
 	{{#each-in links as |l title|}}
 		{{#link-to l}}
 			<div class='account-btn'>
-				{{title}}
+				{{{title}}}
 			</div>
 		{{/link-to}}
 	{{/each-in}}

--- a/addon/templates/components/delete-user.hbs
+++ b/addon/templates/components/delete-user.hbs
@@ -1,13 +1,9 @@
 <div class="ef-account-form">
 	<h1 class="ef-account-form-title">Delete Account</h1>
-	{{#if shouldReauthenticate}}
-		{{#re-authenticate}}{{/re-authenticate}}
-	{{else}}
-		{{#form-for delete_form submit=(action 'deleteUser') as |f|}}
-			<div class="ef-account-form-input">
-				{{f.email-field "email" label="Email" }}
-			</div>
-			{{f.submit "Delete Your Account" class="common-button"}}
-		{{/form-for}}
-	{{/if}}
+	{{#form-for delete_form submit=(action 'deleteUser') as |f|}}
+		<div class="ef-account-form-input">
+			{{f.password-field "currentPassword" label="Current Password" }}
+		</div>
+		{{f.submit "Delete Your Account" class="common-button"}}
+	{{/form-for}}
 </div>

--- a/addon/templates/components/update-email.hbs
+++ b/addon/templates/components/update-email.hbs
@@ -4,6 +4,7 @@
 		{{#re-authenticate}}{{/re-authenticate}}
 	{{else}}
 		{{#form-for email submit=(action 'updateEmail') as |f|}}
+			<div>{{{currentEmailPrompt}}}{{currentEmail}}</div>
 			<div class="ef-account-form-input">
 				{{f.email-field "email" label="Email" }}
 				<br>

--- a/addon/templates/components/update-email.hbs
+++ b/addon/templates/components/update-email.hbs
@@ -1,16 +1,14 @@
 <div class="ef-account-form">
 	<h1 class="ef-account-form-title">Update Email</h1>
-	{{#if shouldReauthenticate}}
-		{{#re-authenticate}}{{/re-authenticate}}
-	{{else}}
-		{{#form-for email submit=(action 'updateEmail') as |f|}}
-			<div>{{{currentEmailPrompt}}}{{currentEmail}}</div>
-			<div class="ef-account-form-input">
-				{{f.email-field "email" label="Email" }}
-				<br>
-				{{f.email-field "emailConfirmation" label="Email Confirmation" }}
-			</div>
-			{{f.submit "Update Info" class="common-button"}}
-		{{/form-for}}
-	{{/if}}
+	{{#form-for email submit=(action 'updateEmail') as |f|}}
+		<div>{{{currentEmailPrompt}}}{{currentEmail}}</div>
+		<div class="ef-account-form-input">
+			{{f.password-field "currentPassword" label="Current Password" }}
+			<br>
+			{{f.email-field "email" label="Email" }}
+			<br>
+			{{f.email-field "emailConfirmation" label="Email Confirmation" }}
+		</div>
+		{{f.submit "Update Info" class="common-button"}}
+	{{/form-for}}
 </div>

--- a/addon/templates/components/update-email.hbs
+++ b/addon/templates/components/update-email.hbs
@@ -1,7 +1,7 @@
 <div class="ef-account-form">
 	<h1 class="ef-account-form-title">Update Email</h1>
 	{{#form-for email submit=(action 'updateEmail') as |f|}}
-		<div>{{{currentEmailPrompt}}}{{currentEmail}}</div>
+		<div class="ef-account-caption">{{{currentEmailPrompt}}}{{currentEmail}}</div>
 		<div class="ef-account-form-input">
 			{{f.password-field "currentPassword" label="Current Password" }}
 			<br>

--- a/addon/templates/components/update-password.hbs
+++ b/addon/templates/components/update-password.hbs
@@ -4,9 +4,9 @@
 		<div class="ef-account-form-input">
 			{{f.password-field "currentPassword" label="Current Password" }}
 			<br>
-			{{f.password-field "password" label="Password" }}
+			{{f.password-field "password" label="New Password" }}
 			<br>
-			{{f.password-field "passwordConfirmation" label="Password Confirmation" }}
+			{{f.password-field "passwordConfirmation" label="New Password Confirmation" }}
 		</div>
 		{{f.submit "Update Password" class="common-button"}}
 	{{/form-for}}

--- a/addon/templates/components/update-password.hbs
+++ b/addon/templates/components/update-password.hbs
@@ -1,15 +1,13 @@
 <div class="ef-account-form">
 	<h1 class="ef-account-form-title">Change Password</h1>
-	{{#if shouldReauthenticate}}
-		{{#re-authenticate}}{{/re-authenticate}}
-	{{else}}
-		{{#form-for password submit=(action 'updatePassword') as |f|}}
-			<div class="ef-account-form-input">
-				{{f.password-field "password" label="Password" }}
-				<br>
-				{{f.password-field "passwordConfirmation" label="Password Confirmation" }}
-			</div>
-			{{f.submit "Update Password" class="common-button"}}
-		{{/form-for}}
-	{{/if}}
+	{{#form-for password submit=(action 'updatePassword') as |f|}}
+		<div class="ef-account-form-input">
+			{{f.password-field "currentPassword" label="Current Password" }}
+			<br>
+			{{f.password-field "password" label="Password" }}
+			<br>
+			{{f.password-field "passwordConfirmation" label="Password Confirmation" }}
+		</div>
+		{{f.submit "Update Password" class="common-button"}}
+	{{/form-for}}
 </div>

--- a/app/instance-initializers/config-initializer.js
+++ b/app/instance-initializers/config-initializer.js
@@ -24,7 +24,8 @@ const DEFAULT_CONFIG = {
       successfulLogout: 'You are now logged out!',
       unsuccessfulLogout: 'We were unable to log out of your account.',
       successfulCreateAccount: 'You have created an account successfully!',
-      unsuccessfulCreateAccount: 'We were unable to create your account.'
+      unsuccessfulCreateAccount: 'We were unable to create your account.',
+      currentEmailPrompt: 'Your current account email adress is: '
     }
 };
 

--- a/app/instance-initializers/config-initializer.js
+++ b/app/instance-initializers/config-initializer.js
@@ -25,7 +25,8 @@ const DEFAULT_CONFIG = {
       unsuccessfulLogout: 'We were unable to log out of your account.',
       successfulCreateAccount: 'You have created an account successfully!',
       unsuccessfulCreateAccount: 'We were unable to create your account.',
-      currentEmailPrompt: 'Your current account email adress is: '
+      currentEmailPrompt: 'Your current account email adress is: ',
+      incorrectPassword: 'That is an incorrect password.'
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
     "ember-cli-mocha": "0.14.4",
     "ember-data": "2.11.0",
     "ember-form-for": "2.0.0-alpha.15",
-    "ember-notify": "5.2.0",
     "emberfire": "firebase/emberfire"
   },
   "devDependencies": {
+    "ember-notify": "5.2.0",
     "broccoli-asset-rev": "2.4.5",
     "ember-ajax": "2.4.1",
     "ember-cli": "2.11.1",


### PR DESCRIPTION
High security pages (update email, update password, delete account) now ask for the user's current password instead of using the reauthenticate component. This also fixes an issue caused by `ember-notify`  and makes it so the account menu is more modular so that the config file can have HTML inputted to it.