### PR TITLE
Updated delete account copy to be more concise

### DIFF
--- a/addon/templates/components/delete-user.hbs
+++ b/addon/templates/components/delete-user.hbs
@@ -4,6 +4,6 @@
 		<div class="ef-account-form-input">
 			{{f.password-field "currentPassword" label="Current Password" }}
 		</div>
-		{{f.submit "Delete Your Account" class="common-button"}}
+		{{f.submit "Delete Account" class="common-button"}}
 	{{/form-for}}
 </div>


### PR DESCRIPTION
This makes it so the button is on one line and is more consistent with the other submission buttons and text in the plugin.